### PR TITLE
Fix PluginInfoProps README

### DIFF
--- a/BepInEx.PluginInfoProps/README.md
+++ b/BepInEx.PluginInfoProps/README.md
@@ -8,7 +8,7 @@ Define the following properties in your `csproj`:
 
 ```xml
 <AssemblyName>Example.Plugin</AssemblyName>
-<Description>My first plugin</Description>
+<Product>My first plugin</Product>
 <Version>1.0.0</Version>
 ```
 


### PR DESCRIPTION
Fixes the incorrect property name in the example `.csproj` code for the `PLUGIN_NAME` string.
`Description` -> `Product`

Addresses #3 