### PR TITLE
Fix the generated plugin info not picking up the name correctly

### DIFF
--- a/BepInEx.Templates/templates/BepInEx5.PluginTemplate/BepInEx5.PluginTemplate.csproj
+++ b/BepInEx.Templates/templates/BepInEx5.PluginTemplate/BepInEx5.PluginTemplate.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>BepInEx5.PluginTemplate</AssemblyName>
-    <Description>My first plugin</Description>
+    <Product>My first plugin</Product>
     <Version>1.0.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>

--- a/BepInEx.Templates/templates/BepInEx6.PluginTemplate.NET.CoreCLR/BepInEx6.PluginTemplate.NET.CoreCLR.csproj
+++ b/BepInEx.Templates/templates/BepInEx6.PluginTemplate.NET.CoreCLR/BepInEx6.PluginTemplate.NET.CoreCLR.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>BepInEx6.PluginTemplate.NET.CoreCLR</AssemblyName>
-    <Description>My first plugin</Description>
+    <Product>My first plugin</Product>
     <Version>1.0.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>

--- a/BepInEx.Templates/templates/BepInEx6.PluginTemplate.NET.Framework/BepInEx6.PluginTemplate.NET.Framework.csproj
+++ b/BepInEx.Templates/templates/BepInEx6.PluginTemplate.NET.Framework/BepInEx6.PluginTemplate.NET.Framework.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net452</TargetFramework>
     <AssemblyName>BepInEx6.PluginTemplate.NET.Framework</AssemblyName>
-    <Description>My first plugin</Description>
+    <Product>My first plugin</Product>
     <Version>1.0.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>

--- a/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Unity.Il2Cpp/BepInEx6.PluginTemplate.Unity.Il2Cpp.csproj
+++ b/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Unity.Il2Cpp/BepInEx6.PluginTemplate.Unity.Il2Cpp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>BepInEx6.PluginTemplate.Unity.Il2Cpp</AssemblyName>
-    <Description>My first plugin</Description>
+    <Product>My first plugin</Product>
     <Version>1.0.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>

--- a/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Unity.Mono/BepInEx6.PluginTemplate.Unity.Mono.csproj
+++ b/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Unity.Mono/BepInEx6.PluginTemplate.Unity.Mono.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>BepInEx6.PluginTemplate.Unity.Mono</AssemblyName>
-    <Description>My first plugin</Description>
+    <Product>My first plugin</Product>
     <Version>1.0.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
So it assigns the description, but that value won't get pickup by PluginInfoProps because it's looking for the product, not the description. This pr makes it change so it takes the product.