### PR TITLE
Update BepInEx.PluginInfoProps.props for better Inter-Mod Referencing

### DIFF
--- a/BepInEx.PluginInfoProps/BepInEx.PluginInfoProps.props
+++ b/BepInEx.PluginInfoProps/BepInEx.PluginInfoProps.props
@@ -7,7 +7,7 @@
             <GeneratedText><![CDATA[
 namespace $(RootNamespace)
 {
-    public static class MyPluginInfo
+    internal static class MyPluginInfo
     {
         public const string PLUGIN_GUID = "$(BepInExPluginGuid)"%3B
         public const string PLUGIN_NAME = "$(BepInExPluginName)"%3B


### PR DESCRIPTION
In version 1.0.0 `MyPluginInfo`, formerly `PluginInfo`, was an internal class. However due to the v1.0.0 `PluginInfo` not having a project-specific namespace, which came the next update when the internal class was converted to a public class as well, it's properties were not accessible to the plugin's scope.  With the update seen in v1.1.0 to correctly namespace the class, it can be kept as `internal` and still allow it's variables to be accessed by the defining mod.

## Benefits
When a library mod is referenced by another plugin, the receiving plugin can scope into the library's namespace and also use BepInEx.PluginInfoProps without any confusion about which `MyPluginInfo` is being referenced.

## Downsides
In order to 'export' your plugin guid the dependent plugin would need to create a `public const` field on their Plugin equal to `MyPluginInfo.PLUGIN_GUID` *however* @js6pak has pointed out that using https://github.com/BepInEx/BepInEx.AutoPlugin will fix that issue and it's a great solution!
