### PR TITLE
.NET SDK 8 Support

### DIFF
--- a/BepInEx.Templates/templates/BepInEx5.PluginTemplate/.template.config/template.json
+++ b/BepInEx.Templates/templates/BepInEx5.PluginTemplate/.template.config/template.json
@@ -37,28 +37,8 @@
       "type": "parameter",
       "description": "Plugin version",
       "datatype": "text",
+      "replaces": "{version}",
       "defaultValue": "1.0.0"
-    },
-    "VersionImpl": {
-      "type": "generated",
-      "generator": "join",
-      "replaces": "<Version>1.0.0</Version>",
-      "parameters": {
-        "symbols": [
-          {
-            "type": "const",
-            "value": "<Version>"
-          },
-          {
-            "type": "ref",
-            "value": "Version"
-          },
-          {
-            "type": "const",
-            "value": "</Version>"
-          }
-        ]
-      }
     }
   }
 }

--- a/BepInEx.Templates/templates/BepInEx5.PluginTemplate/BepInEx5.PluginTemplate.csproj
+++ b/BepInEx.Templates/templates/BepInEx5.PluginTemplate/BepInEx5.PluginTemplate.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>BepInEx5.PluginTemplate</AssemblyName>
     <Product>My first plugin</Product>
-    <Version>1.0.0</Version>
+    <Version>{version}</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RestoreAdditionalProjectSources>

--- a/BepInEx.Templates/templates/BepInEx6.PluginTemplate.NET.CoreCLR/.template.config/template.json
+++ b/BepInEx.Templates/templates/BepInEx6.PluginTemplate.NET.CoreCLR/.template.config/template.json
@@ -30,28 +30,8 @@
       "type": "parameter",
       "description": "Plugin version",
       "datatype": "text",
+      "replaces": "{version}",
       "defaultValue": "1.0.0"
-    },
-    "VersionImpl": {
-      "type": "generated",
-      "generator": "join",
-      "replaces": "<Version>1.0.0</Version>",
-      "parameters": {
-        "symbols": [
-          {
-            "type": "const",
-            "value": "<Version>"
-          },
-          {
-            "type": "ref",
-            "value": "Version"
-          },
-          {
-            "type": "const",
-            "value": "</Version>"
-          }
-        ]
-      }
     }
   }
 }

--- a/BepInEx.Templates/templates/BepInEx6.PluginTemplate.NET.CoreCLR/BepInEx6.PluginTemplate.NET.CoreCLR.csproj
+++ b/BepInEx.Templates/templates/BepInEx6.PluginTemplate.NET.CoreCLR/BepInEx6.PluginTemplate.NET.CoreCLR.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>BepInEx6.PluginTemplate.NET.CoreCLR</AssemblyName>
     <Product>My first plugin</Product>
-    <Version>1.0.0</Version>
+    <Version>{version}</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RestoreAdditionalProjectSources>

--- a/BepInEx.Templates/templates/BepInEx6.PluginTemplate.NET.Framework/.template.config/template.json
+++ b/BepInEx.Templates/templates/BepInEx6.PluginTemplate.NET.Framework/.template.config/template.json
@@ -30,28 +30,8 @@
       "type": "parameter",
       "description": "Plugin version",
       "datatype": "text",
+      "replaces": "{version}",
       "defaultValue": "1.0.0"
-    },
-    "VersionImpl": {
-      "type": "generated",
-      "generator": "join",
-      "replaces": "<Version>1.0.0</Version>",
-      "parameters": {
-        "symbols": [
-          {
-            "type": "const",
-            "value": "<Version>"
-          },
-          {
-            "type": "ref",
-            "value": "Version"
-          },
-          {
-            "type": "const",
-            "value": "</Version>"
-          }
-        ]
-      }
     }
   }
 }

--- a/BepInEx.Templates/templates/BepInEx6.PluginTemplate.NET.Framework/BepInEx6.PluginTemplate.NET.Framework.csproj
+++ b/BepInEx.Templates/templates/BepInEx6.PluginTemplate.NET.Framework/BepInEx6.PluginTemplate.NET.Framework.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net452</TargetFramework>
     <AssemblyName>BepInEx6.PluginTemplate.NET.Framework</AssemblyName>
     <Product>My first plugin</Product>
-    <Version>1.0.0</Version>
+    <Version>{version}</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RestoreAdditionalProjectSources>

--- a/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Unity.Il2Cpp/.template.config/template.json
+++ b/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Unity.Il2Cpp/.template.config/template.json
@@ -30,28 +30,8 @@
       "type": "parameter",
       "description": "Plugin version",
       "datatype": "text",
+      "replaces": "{version}",
       "defaultValue": "1.0.0"
-    },
-    "VersionImpl": {
-      "type": "generated",
-      "generator": "join",
-      "replaces": "<Version>1.0.0</Version>",
-      "parameters": {
-        "symbols": [
-          {
-            "type": "const",
-            "value": "<Version>"
-          },
-          {
-            "type": "ref",
-            "value": "Version"
-          },
-          {
-            "type": "const",
-            "value": "</Version>"
-          }
-        ]
-      }
     }
   }
 }

--- a/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Unity.Il2Cpp/BepInEx6.PluginTemplate.Unity.Il2Cpp.csproj
+++ b/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Unity.Il2Cpp/BepInEx6.PluginTemplate.Unity.Il2Cpp.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>BepInEx6.PluginTemplate.Unity.Il2Cpp</AssemblyName>
     <Product>My first plugin</Product>
-    <Version>1.0.0</Version>
+    <Version>{version}</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RestoreAdditionalProjectSources>

--- a/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Unity.Mono/.template.config/template.json
+++ b/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Unity.Mono/.template.config/template.json
@@ -37,28 +37,8 @@
       "type": "parameter",
       "description": "Plugin version",
       "datatype": "text",
+      "replaces": "{version}",
       "defaultValue": "1.0.0"
-    },
-    "VersionImpl": {
-      "type": "generated",
-      "generator": "join",
-      "replaces": "<Version>1.0.0</Version>",
-      "parameters": {
-        "symbols": [
-          {
-            "type": "const",
-            "value": "<Version>"
-          },
-          {
-            "type": "ref",
-            "value": "Version"
-          },
-          {
-            "type": "const",
-            "value": "</Version>"
-          }
-        ]
-      }
     }
   }
 }

--- a/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Unity.Mono/BepInEx6.PluginTemplate.Unity.Mono.csproj
+++ b/BepInEx.Templates/templates/BepInEx6.PluginTemplate.Unity.Mono/BepInEx6.PluginTemplate.Unity.Mono.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net35</TargetFramework>
     <AssemblyName>BepInEx6.PluginTemplate.Unity.Mono</AssemblyName>
     <Product>My first plugin</Product>
-    <Version>1.0.0</Version>
+    <Version>{version}</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <RestoreAdditionalProjectSources>


### PR DESCRIPTION
As reported in #8, the current templates do not support dotnet SDK 8. This is due to how the templates change the `Version` property in the template's `.csproj`. I believe the method it used came out of worry about changing a `1.0.0` version somewhere else in the templates.

This PR makes a change to how the version is implemented in all templates. This now uses the more typical `"replaces"` argument in the parameter symbol, which both simplifies the `.json` code as well as fixes the issues with using the templates in SDK 8.

This also changes the "target" for replacement from `1.0.0` to `{version}` in the `.csproj`, making it much easier to prevent unwanted version replacements.