### PR TITLE
Add Template CI Github Workflow

### DIFF
--- a/.github/actions/dryrun-templates/action.yml
+++ b/.github/actions/dryrun-templates/action.yml
@@ -1,5 +1,6 @@
 runs:
   using: "composite"
+  shell: bash
   steps:
     - name: Install Templates
       run: |

--- a/.github/actions/dryrun-templates/action.yml
+++ b/.github/actions/dryrun-templates/action.yml
@@ -1,32 +1,37 @@
 runs:
   using: "composite"
-  shell: bash
   steps:
     - name: Install Templates
       run: |
         dotnet new --install ./BepInEx.Templates/templates/
+      shell: bash
         
     - name: Test BepInEx5 Template
       if: always()
       run: |
         dotnet new bepinex5plugin --dry-run --diagnostics
+      shell: bash
     
     - name: Test BepInEx6 .NET Core Template
       if: always()
       run: |
         dotnet new bep6plugin_coreclr --dry-run --diagnostics
+      shell: bash
     
     - name: Test BepInEx6 .NET Framework Template
       if: always()
       run: |
         dotnet new bep6plugin_netfx --dry-run --diagnostics
+      shell: bash
     
     - name: Test BepInEx6 Unity IL2CPP Template
       if: always()
       run: |
         dotnet new bep6plugin_unity_il2cpp --dry-run --diagnostics
+      shell: bash
     
     - name: Test BepInEx6 Unity Mono Template
       if: always()
       run: |
         dotnet new bep6plugin_unity_mono --dry-run --diagnostics
+      shell: bash

--- a/.github/actions/dryrun-templates/action.yml
+++ b/.github/actions/dryrun-templates/action.yml
@@ -1,0 +1,31 @@
+runs:
+  using: "composite"
+  steps:
+    - name: Install Templates
+      run: |
+        dotnet new --install ./BepInEx.Templates/templates/
+        
+    - name: Test BepInEx5 Template
+      if: always()
+      run: |
+        dotnet new bepinex5plugin --dry-run --diagnostics
+    
+    - name: Test BepInEx6 .NET Core Template
+      if: always()
+      run: |
+        dotnet new bep6plugin_coreclr --dry-run --diagnostics
+    
+    - name: Test BepInEx6 .NET Framework Template
+      if: always()
+      run: |
+        dotnet new bep6plugin_netfx --dry-run --diagnostics
+    
+    - name: Test BepInEx6 Unity IL2CPP Template
+      if: always()
+      run: |
+        dotnet new bep6plugin_unity_il2cpp --dry-run --diagnostics
+    
+    - name: Test BepInEx6 Unity Mono Template
+      if: always()
+      run: |
+        dotnet new bep6plugin_unity_mono --dry-run --diagnostics

--- a/.github/workflows/verify-templates.yml
+++ b/.github/workflows/verify-templates.yml
@@ -16,12 +16,13 @@ jobs:
           filter: tree:0
           
       - name: Setup .NET env
-        uses: actions/setup-dotnet@v3
-        id: stepid
+        uses: actions/setup-dotnet@v4
+        id: setup-dotnet
         with:
           dotnet-version: 6.x
 
-      - run: echo '${{ steps.stepid.outputs.dotnet-version }}'
+      - run: |
+          dotnet new globaljson --sdk-version ${{ steps.setup-dotnet.outputs.dotnet-version }}
 
       - name: Dry-run Templates
         uses: ./.github/actions/dryrun-templates
@@ -37,12 +38,13 @@ jobs:
           filter: tree:0
 
       - name: Setup .NET env
-        uses: actions/setup-dotnet@v3
-        id: stepid
+        uses: actions/setup-dotnet@v4
+        id: setup-dotnet
         with:
           dotnet-version: 7.x
 
-      - run: echo '${{ steps.stepid.outputs.dotnet-version }}'
+      - run: |
+          dotnet new globaljson --sdk-version ${{ steps.setup-dotnet.outputs.dotnet-version }}
 
       - name: Dry-run Templates
         uses: ./.github/actions/dryrun-templates
@@ -58,12 +60,13 @@ jobs:
           filter: tree:0
 
       - name: Setup .NET env
-        uses: actions/setup-dotnet@v3
-        id: stepid
+        uses: actions/setup-dotnet@v4
+        id: setup-dotnet
         with:
           dotnet-version: 8.x
 
-      - run: echo '${{ steps.stepid.outputs.dotnet-version }}'
+      - run: |
+          dotnet new globaljson --sdk-version ${{ steps.setup-dotnet.outputs.dotnet-version }}
 
       - name: Dry-run Templates
         uses: ./.github/actions/dryrun-templates

--- a/.github/workflows/verify-templates.yml
+++ b/.github/workflows/verify-templates.yml
@@ -1,0 +1,60 @@
+name: Verify Templates
+
+on:
+  push:
+  pull_request:
+  
+jobs:
+  test-sdk6:
+    name: Test .NET SDK 6
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Sources
+        uses: actions/checkout@v4
+        with:
+          filter-depth: 0
+          filter: tree:0
+          
+      - name: Setup .NET env
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "6.0.418"
+
+      - name: Dry-run Templates
+        uses: ./.github/actions/dryrun-templates
+  
+  test-sdk7:
+    name: Test .NET SDK 7
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Sources
+        uses: actions/checkout@v4
+        with:
+          filter-depth: 0
+          filter: tree:0
+
+      - name: Setup .NET env
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "7.0.405"
+
+      - name: Dry-run Templates
+        uses: ./.github/actions/dryrun-templates
+    
+  test-sdk8:
+    name: Test .NET SDK 8
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Sources
+        uses: actions/checkout@v4
+        with:
+          filter-depth: 0
+          filter: tree:0
+
+      - name: Setup .NET env
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.101"
+
+      - name: Dry-run Templates
+        uses: ./.github/actions/dryrun-templates

--- a/.github/workflows/verify-templates.yml
+++ b/.github/workflows/verify-templates.yml
@@ -17,6 +17,7 @@ jobs:
           
       - name: Setup .NET env
         uses: actions/setup-dotnet@v4
+        id: stepid
         with:
           dotnet-version: 6.x
 
@@ -37,6 +38,7 @@ jobs:
 
       - name: Setup .NET env
         uses: actions/setup-dotnet@v4
+        id: stepid
         with:
           dotnet-version: 7.x
 
@@ -57,6 +59,7 @@ jobs:
 
       - name: Setup .NET env
         uses: actions/setup-dotnet@v4
+        id: stepid
         with:
           dotnet-version: 8.x
 

--- a/.github/workflows/verify-templates.yml
+++ b/.github/workflows/verify-templates.yml
@@ -11,9 +11,6 @@ jobs:
     steps:
       - name: Fetch Sources
         uses: actions/checkout@v4
-        with:
-          filter-depth: 0
-          filter: tree:0
           
       - name: Setup .NET env
         uses: actions/setup-dotnet@v4
@@ -33,9 +30,6 @@ jobs:
     steps:
       - name: Fetch Sources
         uses: actions/checkout@v4
-        with:
-          filter-depth: 0
-          filter: tree:0
 
       - name: Setup .NET env
         uses: actions/setup-dotnet@v4
@@ -55,9 +49,6 @@ jobs:
     steps:
       - name: Fetch Sources
         uses: actions/checkout@v4
-        with:
-          filter-depth: 0
-          filter: tree:0
 
       - name: Setup .NET env
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/verify-templates.yml
+++ b/.github/workflows/verify-templates.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup .NET env
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "6.0.418"
+          dotnet-version: 6.x
 
       - name: Dry-run Templates
         uses: ./.github/actions/dryrun-templates
@@ -36,7 +36,7 @@ jobs:
       - name: Setup .NET env
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "7.0.405"
+          dotnet-version: 7.x
 
       - name: Dry-run Templates
         uses: ./.github/actions/dryrun-templates
@@ -54,7 +54,7 @@ jobs:
       - name: Setup .NET env
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "8.0.101"
+          dotnet-version: 8.x
 
       - name: Dry-run Templates
         uses: ./.github/actions/dryrun-templates

--- a/.github/workflows/verify-templates.yml
+++ b/.github/workflows/verify-templates.yml
@@ -16,7 +16,7 @@ jobs:
           filter: tree:0
           
       - name: Setup .NET env
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v3
         id: stepid
         with:
           dotnet-version: 6.x
@@ -37,7 +37,7 @@ jobs:
           filter: tree:0
 
       - name: Setup .NET env
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v3
         id: stepid
         with:
           dotnet-version: 7.x
@@ -58,7 +58,7 @@ jobs:
           filter: tree:0
 
       - name: Setup .NET env
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v3
         id: stepid
         with:
           dotnet-version: 8.x

--- a/.github/workflows/verify-templates.yml
+++ b/.github/workflows/verify-templates.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           dotnet-version: 6.x
 
+      - run: echo '${{ steps.stepid.outputs.dotnet-version }}'
+
       - name: Dry-run Templates
         uses: ./.github/actions/dryrun-templates
   
@@ -38,6 +40,8 @@ jobs:
         with:
           dotnet-version: 7.x
 
+      - run: echo '${{ steps.stepid.outputs.dotnet-version }}'
+
       - name: Dry-run Templates
         uses: ./.github/actions/dryrun-templates
     
@@ -55,6 +59,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.x
+
+      - run: echo '${{ steps.stepid.outputs.dotnet-version }}'
 
       - name: Dry-run Templates
         uses: ./.github/actions/dryrun-templates


### PR DESCRIPTION
This PR adds a github workflow that will attempt to create projects from the templates in all supported dotnet SDK versions (6, 7, & 8) when a push to any branch or a PR is made (if the action is approved to run).

This acts as two checks. The first, to make sure templates can be used at all. The second, to make sure templates can be used in all of the supported SDK versions.

### Note

If any template has a required parameter/argument added, the `.github/actions/dryrun-templates/action.yml` file must be updated accordingly to include the required argument for that template. Otherwise, the workflow will fail.

This workflow will also fail currently due to the templates not working on SDK 8.