### PR TITLE
Added F# Support to BepInEx.PluginInfoProps

### DIFF
--- a/BepInEx.PluginInfoProps/BepInEx.PluginInfoProps.props
+++ b/BepInEx.PluginInfoProps/BepInEx.PluginInfoProps.props
@@ -1,10 +1,14 @@
 <Project>
-    <Target Name="AddGeneratedFile" BeforeTargets="BeforeCompile;CoreCompile" Inputs="$(MSBuildAllProjects)" Outputs="$(IntermediateOutputPath)GeneratedFile.cs">
+    <PropertyGroup>
+        <FileExtension Condition="$(MSBuildProjectExtension) == '.fsproj'">fs</FileExtension>
+        <FileExtension Condition="$(MSBuildProjectExtension) == '.csproj'">cs</FileExtension>
+    </PropertyGroup>
+    <Target Name="AddGeneratedFile" BeforeTargets="BeforeCompile;CoreCompile" Inputs="$(MSBuildAllProjects)" Outputs="$(IntermediateOutputPath)GeneratedFile.$(FileExtension)">
         <PropertyGroup>
             <BepInExPluginGuid Condition="'$(BepInExPluginGuid)' == ''">$(AssemblyName)</BepInExPluginGuid>
             <BepInExPluginName Condition="'$(BepInExPluginName)' == ''">$(Product)</BepInExPluginName>
             <BepInExPluginVersion Condition="'$(BepInExPluginVersion)' == ''">$(Version)</BepInExPluginVersion>
-            <GeneratedText><![CDATA[
+            <GeneratedText Condition="'$(FileExtension)' == 'cs'"><![CDATA[
 namespace $(RootNamespace)
 {
     internal static class MyPluginInfo
@@ -15,10 +19,25 @@ namespace $(RootNamespace)
     }
 }
       ]]></GeneratedText>
-            <GeneratedFilePath>$(IntermediateOutputPath)MyPluginInfo.cs</GeneratedFilePath>
+            <GeneratedText Condition="'$(FileExtension)' == 'fs'"><![CDATA[
+namespace $(RootNamespace)
+
+module internal MyPluginInfo = 
+    [<Literal>] 
+    let PLUGIN_GUID: string = "$(BepInExPluginGuid)"
+    [<Literal>] 
+    let PLUGIN_NAME: string = "$(BepInExPluginName)"
+    [<Literal>] 
+    let PLUGIN_VERSION: string = "$(BepInExPluginVersion)"
+      ]]></GeneratedText>
+            <GeneratedFilePath>$(IntermediateOutputPath)MyPluginInfo.$(FileExtension)</GeneratedFilePath>
         </PropertyGroup>
         <ItemGroup>
+            <FSharpOrderedCompile Include="@(Compile)" Condition="'$(FileExtension)' == 'fs'"/> <!-- Here we save F#'s ordered compilation -->
+            <Compile Remove="@(FSharpOrderedCompile)" Condition="'$(FileExtension)' == 'fs'"/>  <!-- because FSC cares about the order.    -->
+
             <Compile Include="$(GeneratedFilePath)" />
+            <Compile Include="@(FSharpOrderedCompile)" Condition="'$(FileExtension)' == 'fs'"/> <!-- Add after so PluginInfo is accessible.-->
             <FileWrites Include="$(GeneratedFilePath)" />
         </ItemGroup>
         <WriteLinesToFile Lines="$(GeneratedText)" File="$(GeneratedFilePath)" WriteOnlyWhenDifferent="true" Overwrite="true" />

--- a/BepInEx.PluginInfoProps/README.md
+++ b/BepInEx.PluginInfoProps/README.md
@@ -1,10 +1,12 @@
 ## BepInEx PluginInfo generator
 
-Generates `MyPluginInfo.cs` based on csproj tags.
+Generates a `MyPluginInfo.cs`, or `.fs`, based on project tags.
+
+Supports C# & F# projects, and will read the `.csproj` or `.fsproj` to determine values.
 
 ## Basic usage
 
-Define the following properties in your `csproj`:
+Define the following properties in your project file:
 
 ```xml
 <AssemblyName>Example.Plugin</AssemblyName>
@@ -14,13 +16,23 @@ Define the following properties in your `csproj`:
 
 this will generate the following class:
 
+**C#**
 ```cs
-using System;
-
 internal static class MyPluginInfo
 {
     public const string PLUGIN_GUID = "Example.Plugin";
     public const string PLUGIN_NAME = "My first plugin";
     public const string PLUGIN_VERSION = "1.0.0";
 }
+```
+
+**F#**
+```fsharp
+module internal MyPluginInfo = 
+    [<Literal>] 
+    let PLUGIN_GUID: string = "Example.Plugin"
+    [<Literal>] 
+    let PLUGIN_NAME: string = "My first plugin"
+    [<Literal>] 
+    let PLUGIN_VERSION: string = "1.0.0"
 ```


### PR DESCRIPTION
### Expands functionality of BepInEx.PluginInfoProps' auto-generation.
I won't get into the debate of using F# to mod, but adding support is somewhat trivial, with the exception of F#'s dependency-based compilation order throwing a wrench in the plans. Thankfully, or maybe regrettably, detecting the language via project file extension is easy enough to then determine file contents, extension, and how we handle compilation insertion. 

Traditionally, the \<Compile\> is all that's necessary, but FSharp's compiler will take that as the final file and so it won't be visible by any \<Compile\> files declared before it (which is all the .fsproj files). In order to avoid this, we store the compile into an interim item and reinsert it *after* we add MyPluginInfo's compile tag. Woohoo, just like that we supprt MyPluginInfo goodness in a few more mods in all of the ecosystem; but hey! "Functionality" (ᵖˡᵘˢ ⁱ'ᵈ ˡᵒᵛᵉ ⁱᵗ ˡᵒˡ)