### PR TITLE
Use <GUID> property if present for BepInExPluginGuid

### DIFF
--- a/BepInEx.PluginInfoProps/BepInEx.PluginInfoProps.props
+++ b/BepInEx.PluginInfoProps/BepInEx.PluginInfoProps.props
@@ -1,6 +1,7 @@
 <Project>
     <Target Name="AddGeneratedFile" BeforeTargets="BeforeCompile;CoreCompile" Inputs="$(MSBuildAllProjects)" Outputs="$(IntermediateOutputPath)GeneratedFile.cs">
         <PropertyGroup>
+            <BepInExPluginGuid Condition="'$(BepInExPluginGuid)' == ''">$(GUID)</BepInExPluginGuid>
             <BepInExPluginGuid Condition="'$(BepInExPluginGuid)' == ''">$(AssemblyName)</BepInExPluginGuid>
             <BepInExPluginName Condition="'$(BepInExPluginName)' == ''">$(Product)</BepInExPluginName>
             <BepInExPluginVersion Condition="'$(BepInExPluginVersion)' == ''">$(Version)</BepInExPluginVersion>

--- a/BepInEx.PluginInfoProps/README.md
+++ b/BepInEx.PluginInfoProps/README.md
@@ -7,7 +7,7 @@ Generates `MyPluginInfo.cs` based on csproj tags.
 Define the following properties in your `csproj`:
 
 ```xml
-<AssemblyName>Example.Plugin</AssemblyName>
+<GUID>Example.Plugin</GUID> <!--  Optional. If missing, <AssemblyName> is used as GUID instead. -->
 <Product>My first plugin</Product>
 <Version>1.0.0</Version>
 ```


### PR DESCRIPTION
Using the AssemblyName isn't always useful or unique for plugin GUIDs, so an optional <GUID> custom property can be defined so they can be kept separate, especially if a plugin developer decides to change the assembly name for whatever reason.